### PR TITLE
Adds support for Sentry.io logging

### DIFF
--- a/PokeFacts/Config.py
+++ b/PokeFacts/Config.py
@@ -27,9 +27,10 @@ APP_SECRET      = Secrets.APP_SECRET
 # ---------------------
 
 DEVELOPERS      = "/u/kwwxis, /u/Haruka-sama"
-VERSION         = "1.0.0"
+VERSION         = "1.0.1"
 DESCRIPTION     = "Responds to specific text in pokemon subreddits with a response"
 USERAGENT       = USERNAME + ":" + DESCRIPTION + " v" + VERSION + " by " + DEVELOPERS
+DSN             = "https://103153c555104b6695bc06dc10252c62:ffa3fc21a9ed48aaad63b3109f329fec@sentry.io/1197206"
 
 # OPERATOR CONFIG
 # ---------------

--- a/PokeFacts/RedditBot.py
+++ b/PokeFacts/RedditBot.py
@@ -42,7 +42,7 @@ try:
     from layer7_utilities import Logger
 except ImportError:
     class Logger():
-        def __init__(self, botname, botversion):
+        def __init__(self, DSN, botname, botversion):
             self.botname = botname
             self.botversion = botversion
         def info(self, msg):
@@ -64,7 +64,7 @@ class CallResponse():
         self.startTime  = time.time()
         self.scriptfile = os.path.abspath(__file__)
         self.scriptpath = os.path.dirname(self.scriptfile)
-        self.logger     = Logger(Config.USERNAME, Config.VERSION)
+        self.logger     = Logger(DSN, Config.USERNAME, Config.VERSION)
         
         self.logger.info('Bot started, initializing...')
         self.r = Config.reddit() if reddit is None else reddit


### PR DESCRIPTION
Layer7's Logging package added a required 'DSN' field which is what sentry.io uses for advanced error reporting analytics. This PR adds the required DN value for it. If someone doesn't use Sentry.io they can just pass an empty string to the logging class which will be ignored.